### PR TITLE
Clean up and refactor the entire project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,30 +13,28 @@ an example image. switch to dark mode if you can't see it.
 ## How to use
 
 ### 1. Install
-`pip install pillow tcod numpy PIL`
-
-There might be more dependencies missing. If so, you should install them the same way.  I'll accept PRs to update the list of deps, but I rarely write Python and can't be bothered to set up a clean-room environment to figure them out myself.
+`pip install pillow tcod numpy`
 
 ### 2. Use
 See the usage string:
 ```
 $ ./make_tileset.py -h
-$ python3 make_tileset.py -h                                                                                                                                                                                                                                                                                        126 ↵
-usage: make_tileset.py [-h] input_file width_px height_px output_file
+$ python3 make_tileset.py -h
+usage: make_tileset.py [-h] --height HEIGHT [--width WIDTH] [-o OUT] input_file
 
 positional arguments:
-  input_file   a truetype (.ttf) font file
-  width_px     width of a glpyh('s bounding box) in px
-  height_px    height of a glyph('s bounding box) in px
-  output_file  the path to write the output file
+  input_file         A truetype (.ttf) font file.
 
-optional arguments:
-  -h, --help   show this help message and exit
+options:
+  -h, --help         show this help message and exit
+  --height HEIGHT    Height of each glyph (bounding box) in pixels.
+  --width WIDTH      Width of each glyph (bounding box) in pixels. (Optional)
+  -o OUT, --out OUT  The output file. (Defaults to <input>.png)
 ```
 
 Exact command used to generate the example image:
 ```
-python make_tileset.py Px437_IBM_Model3x_Alt3.ttf 8 16 ibm_model3x_8x16.png
+python make_tileset.py Px437_IBM_Model3x_Alt3.ttf --width 8 --height 16
 ```
 Font file was found at https://int10h.org/oldschool-pc-fonts
 

--- a/make_tileset.py
+++ b/make_tileset.py
@@ -1,59 +1,59 @@
 #!/usr/bin/env python3
 
 import argparse
-import io
+from typing import Any, Optional
+
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
-import tcod
-import PIL.Image as Image
-import PIL.ImageFont as ImageFont
-import PIL.ImageDraw as ImageDraw
+import tcod.tileset
+from numpy.typing import NDArray
+from PIL import Image, ImageDraw, ImageFont  # type: ignore
 
-from tcod.loader import lib
-from tcod.tileset import CHARMAP_CP437
+# Code page 437 Unicode codepoints as a 16x16 grid, row-major order.
+CHARMAP_CP437 = np.asarray(tcod.tileset.CHARMAP_CP437, dtype=int).reshape(16, 16)
 
-CP437_LEN=256
-IMAGE_W_CELLS=16
-IMAGE_H_CELLS=16
 
-def write_cp437(font_path, width_px, height_px): # -> ndarray[uint8]
-    tileset = tcod.tileset.load_truetype_font(
-        font_path,
-        tile_width=width_px,
-        tile_height=height_px,
-    )
-    for i in range(256):
-        tileset.remap(tcod.tileset.CHARMAP_CP437[i], i)
+def render(charmap: NDArray[Any], font: ImageFont, width_px: int, height_px: int) -> Image:
+    """Render a tileset image using pillow.
 
-    buf = np.zeros(
-            shape=(IMAGE_W_CELLS, IMAGE_H_CELLS),
-            dtype=tcod.console.Console.DTYPE,
-            order="F"
-    )
-    for x in range(IMAGE_W_CELLS):
-        for y in range(IMAGE_H_CELLS):
-            buf[x, y] = tcod.tileset.CHARMAP_CP437[(IMAGE_W_CELLS * x) + y]
+    Args:
+        charmap (np.ndarray): A 2D grid of codepoints to render.
+        font (ImageFont): The font to be rendered.
+        width_px (int): The pixel width of each rendered glyph.
+        height_px (int): The pixel height of each rendered glyph.
 
-    return buf
-
-def render(buf: NDArray[np.uint8], font: ImageFont, width_px: int, height_px: int):
-    canvas_w = IMAGE_W_CELLS * width_px
-    canvas_h = IMAGE_H_CELLS * height_px
-    canvas = Image.new('RGBA', (canvas_w, canvas_h))
+    Returns:
+        Image: A rendered tileset with the shape and characters of charmap and the glyphs of font.
+    """
+    IMAGE_H_CELLS, IMAGE_W_CELLS = charmap.shape
+    canvas = Image.new("RGBA", (IMAGE_W_CELLS * width_px, IMAGE_H_CELLS * height_px))
     draw = ImageDraw.Draw(canvas)
 
-    for cellX in range(IMAGE_W_CELLS):
-        for cellY in range(IMAGE_H_CELLS):
-            draw.text((width_px * cellX, height_px * cellY), chr(buf[cellY, cellX][0]), fill='white', font=font)
+    for cell_y, row in enumerate(charmap):
+        for cell_x, char in enumerate(row):
+            draw.text((width_px * cell_x, height_px * cell_y), chr(char), fill="white", font=font)
     return canvas
 
-parser = argparse.ArgumentParser()
-parser.add_argument("input_file", help="a truetype (.ttf) font file")
-parser.add_argument("width_px", type=int, help="width of a glpyh('s bounding box) in px")
-parser.add_argument("height_px", type=int, help="height of a glyph('s bounding box) in px")
-parser.add_argument("output_file", help="the path to write the output file")
-args = parser.parse_args()
 
-buf = write_cp437(args.input_file, args.width_px, args.height_px)
-font = ImageFont.truetype(args.input_file, size=args.height_px)
-render(buf, font, args.width_px, args.height_px).save(args.output_file)
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_file", type=str, help="A truetype (.ttf) font file.")
+    parser.add_argument("--height", type=int, help="Height of each glyph (bounding box) in pixels.", required=True)
+    parser.add_argument("--width", type=int, help="Width of each glyph (bounding box) in pixels. (Optional)", default=0)
+    parser.add_argument("-o", "--out", type=str, help="The output file. (Defaults to <input>.png)", default=None)
+    args = parser.parse_args()
+
+    out_file: Optional[str] = args.out
+    if out_file is None:  # Replace the input file extension with png by default.
+        out_file = args.input_file.rsplit(".", 1)[0] + ".png"
+
+    tile_height: int = args.height
+    font = ImageFont.truetype(args.input_file, size=tile_height)
+    tile_width: int = args.width
+    if not tile_width:  # Attempt to derive tile pixel width from the font.
+        tile_width = font.getsize("A")[0]
+
+    render(CHARMAP_CP437, font, tile_width, tile_height).save(out_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pillow
+tcod
+numpy


### PR DESCRIPTION
No longer creates a character map from tcod in a roundabout way.  The character map is now made directly from `tcod.tileset.CHARMAP_CP437`.

Several assumptions were removed from the render function.  This now supports alternative character maps easily, or tilesets with different shapes and sizes.

CLI options were refactored.  The width and output file and now optional.  The readme has been updated for the new options.

Set the executable flag on `make_tileset.py` in Git.

Cleaned up requirements.  PIL isn't needed when pillow is installed.  The `requirements.txt` file is standard.

The code has been reformatted using Black and isort.